### PR TITLE
Remove attempt to call Flattr::Thing.new on a newly created thing.

### DIFF
--- a/lib/flattr/client/things.rb
+++ b/lib/flattr/client/things.rb
@@ -52,7 +52,7 @@ module Flattr
       # Raises Flattr::Error::NotFound if thing was not found
       def thing_new(url, opts = {})
         response = post("/rest/v2/things", opts.merge(:url => url))
-        thing = thing(response["id"])
+        thing(response["id"])
       end
 
       # Public: Update a thing


### PR DESCRIPTION
This was blocking creating new things, raising a rather unintuitive NoMethodError even though the API call itself has succeeded. As patched it returns the new thing, as per the doc.
