### PR TITLE
Bumb required version of multi_json to 1.3.2

### DIFF
--- a/flattr.gemspec
+++ b/flattr.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'faraday', '~> 0.7'
-  s.add_dependency 'multi_json', '~> 1.0'
+  s.add_dependency 'multi_json', '~> 1.3.2'
 
   s.add_development_dependency 'json'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
`MultiJson.dump` was only introduced in version 1.3.2. So I set the version in the gemspec accordingly.
